### PR TITLE
Added podspec

### DIFF
--- a/SNRFetchedResultsController.podspec
+++ b/SNRFetchedResultsController.podspec
@@ -1,0 +1,13 @@
+Pod::Spec.new do |spec|
+  spec.name         = 'SNRFetchedResultsController'
+  spec.version      = '0.0.1'
+  spec.license      = { :type => 'BSD' }
+  spec.homepage     = 'https://github.com/indragiek/SNRFetchedResultsController'
+  spec.authors      = { 'Indragie Karunaratne' => 'i@indragie.com' }
+  spec.summary      = 'Automatic Core Data change tracking for OS X (NSFetchedResultsController port).'
+  spec.source       = { :git => 'https://github.com/indragiek/SNRFetchedResultsController.git', :tag => 'v0.0.1' }
+  spec.source_files = 'SNRFetchedResultsController.{h,m}'
+  spec.framework    = 'SystemConfiguration'
+  spec.platform     = :osx
+  spec.requires_arc = true
+end


### PR DESCRIPTION
Adding a `.podspec` file to the repo.

Among other perks, it allows forks to be inserted via Cocoapods using the `:git` tag (e.g. `pod 'SNRFetchedResultsController', :git => 'https://github.com/mittsh/SNRFetchedResultsController.git', :commit => '3d02b9f778'`).