### PR TITLE
Bugfix sortdescriptor update

### DIFF
--- a/SNRFetchedResultsController.m
+++ b/SNRFetchedResultsController.m
@@ -165,10 +165,8 @@
                 update.originalIndex = objectIndex;
                 update.object = object;
                 [updated addObject:update];
-            } else {
-                // If there's no change in sorting then just update the object as-is
-                [self delegateDidChangeObject:object atIndex:objectIndex forChangeType:SNRFetchedResultsChangeUpdate newIndex:objectIndex];
             }
+			[self delegateDidChangeObject:object atIndex:objectIndex forChangeType:SNRFetchedResultsChangeUpdate newIndex:objectIndex];
         }
     }
     // If there were updated objects that changed the sorting then resort and notify the delegate of changes
@@ -177,7 +175,10 @@
         for (SNRFetchedResultsUpdate *update in updated) {
             // Find out then new index of the object in the content array
             NSUInteger newIndex = [sFetchedObjects indexOfObject:update.object];
-            [self delegateDidChangeObject:update.object atIndex:update.originalIndex forChangeType:SNRFetchedResultsChangeMove newIndex:newIndex];
+			// If the new index is different from the old one
+			if (update.originalIndex != newIndex) {
+				[self delegateDidChangeObject:update.object atIndex:update.originalIndex forChangeType:SNRFetchedResultsChangeMove newIndex:newIndex];
+			}
         }
     }
     for (NSManagedObject *object in insertedObjects) {


### PR DESCRIPTION
This fixes a bug I noticed a long time ago (and neglected to submit a PR so far...). It sounds like when the value of an object key gets changed, while this key describes a sort descriptor, a *move* update was always sent, even if the object hasn't moved, and the *change* update isn't triggered.

*Disclaimer: I've experienced that issue in my project ([Paw](luckymarmot.com/paw)), and this fix worked. Never tried it in an independent test project to actually prove this theory. It probably needs some more extensive testing before being merged.*